### PR TITLE
Support for Laravel 10.x and Livewire 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require":{
         "php": "^8.0",
-        "asantibanez/livewire-charts": "^2.4",
+        "asantibanez/livewire-charts": "^3.0.1",
         "ext-posix": "*",
         "ext-pcntl": "*"
     },


### PR DESCRIPTION
Added support for Laravel 10.x and the latest Livewire.

Resolved #12 